### PR TITLE
feat: add Dropdown component

### DIFF
--- a/src/lib/components/Dropdown.svelte
+++ b/src/lib/components/Dropdown.svelte
@@ -1,0 +1,134 @@
+<script lang="ts">
+	interface Props {
+		label?: string;
+		options: { value: string; label: string }[];
+		value?: string;
+		onchange?: (value: string) => void;
+		placeholder?: string;
+		class?: string;
+		id?: string;
+	}
+
+	let {
+		label,
+		options,
+		value = $bindable(''),
+		onchange,
+		placeholder = 'Select an option',
+		class: className = '',
+		id = `dropdown-${Math.random().toString(36).substring(2, 9)}`
+	}: Props = $props();
+
+	let isOpen = $state(false);
+	let dropdownRef = $state<HTMLDivElement | null>(null);
+
+	const selectedOption = $derived(
+		options.find((opt) => opt.value === value) || { label: placeholder, value: '' }
+	);
+
+	function toggleDropdown() {
+		isOpen = !isOpen;
+	}
+
+	function selectOption(optionValue: string) {
+		value = optionValue;
+		isOpen = false;
+		onchange?.(optionValue);
+	}
+
+	function handleClickOutside(event: MouseEvent) {
+		if (dropdownRef && !dropdownRef.contains(event.target as Node)) {
+			isOpen = false;
+		}
+	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (event.key === 'Escape') {
+			isOpen = false;
+		}
+	}
+
+	$effect(() => {
+		if (isOpen) {
+			document.addEventListener('click', handleClickOutside);
+			document.addEventListener('keydown', handleKeydown);
+
+			return () => {
+				document.removeEventListener('click', handleClickOutside);
+				document.removeEventListener('keydown', handleKeydown);
+			};
+		}
+	});
+</script>
+
+<div bind:this={dropdownRef} class="relative w-full {className}">
+	{#if label}
+		<label for={id} class="mb-1 block text-sm font-medium text-gray-700">{label}</label>
+	{/if}
+
+	<button
+		{id}
+		type="button"
+		onclick={toggleDropdown}
+		class="flex w-full items-center justify-between rounded-lg border border-gray-300 bg-white px-4 py-2 text-left transition-all duration-200 hover:border-purple-400 focus:border-purple-500 focus:ring-2 focus:ring-purple-500/20 focus:outline-none"
+		aria-haspopup="listbox"
+		aria-expanded={isOpen}
+	>
+		<span class={value ? 'text-gray-900' : 'text-gray-500'}>
+			{selectedOption.label}
+		</span>
+		<svg
+			class="h-5 w-5 transform text-gray-400 transition-transform duration-200 {isOpen
+				? 'rotate-180'
+				: ''}"
+			fill="none"
+			stroke="currentColor"
+			viewBox="0 0 24 24"
+		>
+			<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+		</svg>
+	</button>
+
+	{#if isOpen}
+		<div
+			class="absolute z-10 mt-1 w-full animate-fadeIn rounded-lg border border-gray-200 bg-white shadow-lg"
+			role="listbox"
+		>
+			<ul class="max-h-60 overflow-auto rounded-lg py-1">
+				{#each options as option (option.value)}
+					<li>
+						<button
+							type="button"
+							onclick={() => selectOption(option.value)}
+							class="block w-full px-4 py-2 text-left transition-colors duration-150 hover:bg-purple-50 hover:text-purple-900 {option.value ===
+							value
+								? 'bg-purple-100 font-medium text-purple-900'
+								: 'text-gray-700'}"
+							role="option"
+							aria-selected={option.value === value}
+						>
+							{option.label}
+						</button>
+					</li>
+				{/each}
+			</ul>
+		</div>
+	{/if}
+</div>
+
+<style>
+	@keyframes fadeIn {
+		from {
+			opacity: 0;
+			transform: translateY(-8px);
+		}
+		to {
+			opacity: 1;
+			transform: translateY(0);
+		}
+	}
+
+	.animate-fadeIn {
+		animation: fadeIn 0.15s ease-out;
+	}
+</style>

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,6 +1,7 @@
 export { default as Button } from './components/Button.svelte';
 export { default as Card } from './components/Card.svelte';
 export { default as Counter } from './components/Counter.svelte';
+export { default as Dropdown } from './components/Dropdown.svelte';
 export { default as Modal } from './components/Modal.svelte';
 export { default as Slider } from './components/Slider.svelte';
 export {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,10 +1,18 @@
 <script lang="ts">
-	import { Button, Card, Counter, Modal, Slider } from '$lib';
+	import { Button, Card, Counter, Dropdown, Modal, Slider } from '$lib';
 
 	let sliderValue = $state(50);
+	let dropdownValue = $state('');
 	let isBasicModalOpen = $state(false);
 	let isFormModalOpen = $state(false);
 	let isLargeModalOpen = $state(false);
+
+	const dropdownOptions = [
+		{ value: 'svelte', label: 'Svelte' },
+		{ value: 'react', label: 'React' },
+		{ value: 'vue', label: 'Vue' },
+		{ value: 'angular', label: 'Angular' }
+	];
 </script>
 
 <div class="flex min-h-screen flex-col items-center justify-center gap-8 p-8">
@@ -27,6 +35,25 @@
 			<div class="mt-4 w-full">
 				<Slider bind:value={sliderValue} />
 				<p class="mt-2 text-center text-sm text-gray-600">Value: {sliderValue}</p>
+			</div>
+		</Card>
+
+		<Card
+			title="Dropdown Menu"
+			description="A customizable dropdown component with smooth animations and keyboard support."
+		>
+			<div class="mt-4 w-full">
+				<Dropdown
+					label="Choose your framework"
+					options={dropdownOptions}
+					bind:value={dropdownValue}
+					placeholder="Select a framework"
+				/>
+				{#if dropdownValue}
+					<p class="mt-2 text-center text-sm text-gray-600">
+						Selected: {dropdownOptions.find((o) => o.value === dropdownValue)?.label}
+					</p>
+				{/if}
 			</div>
 		</Card>
 


### PR DESCRIPTION
Adds a new Dropdown component to the component library and demonstrates it on the main page.

## Changes
- Created new Dropdown component using Svelte 5 runes
- Supports label, placeholder, options, and two-way binding
- Includes smooth animations and keyboard support (ESC to close)
- Added accessibility features (proper label association, ARIA attributes)
- Integrated dropdown into main page with framework selection example
- Styled with Tailwind CSS for consistency with existing components

Closes #86

Generated with [Claude Code](https://claude.ai/code)